### PR TITLE
add fields to device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ The information available in the array of Passage Device struct returned by Pass
                :cred_id,
                :friendly_name,
                :usage_count,
-               :last_used,
+               :updated_at,
+               :created_at,
+               :last_login_at,
 
 ```
 

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -51,7 +51,9 @@ module Passage
                :cred_id,
                :friendly_name,
                :usage_count,
-               :last_used,
+               :updated_at,
+               :created_at,
+               :last_login_at,
                keyword_init: true
 
   COOKIE_STRATEGY = 0

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -229,7 +229,7 @@ module Passage
               usage_count: device["usage_count"],
               updated_at: device["updated_at"],
               created_at: device["created_at"],
-              last_login_at: device["last_login_at"],
+              last_login_at: device["last_login_at"]
             )
           )
         end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -227,7 +227,9 @@ module Passage
               cred_id: device["cred_id"],
               friendly_name: device["friendly_name"],
               usage_count: device["usage_count"],
-              last_used: device["last_used"]
+              updated_at: device["updated_at"],
+              created_at: device["created_at"],
+              last_login_at: device["last_login_at"],
             )
           )
         end


### PR DESCRIPTION
### Overview of Changes in this PR

-   add `last_login_at` to device type

#### Minor changes

-   update fields returned by device API:
    - -`last_used`
    - +`updated_at`
    - +`created_at`
---
Before device names could be updated, the `updated_at` value indicated the last login.
Now it indicates the last login _or_ the last name change.

This new `last_login_at` value accurately reflects the last login, even after a device name change.
