### PR TITLE
sc-1254/bump gem version

### DIFF
--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'passageidentity'
-  s.version = '0.0.7'
+  s.version = '0.0.8'
   s.summary = 'Passage SDK for biometric authentication'
   s.description =
     'Enables verification of server-side authentication and user management for applications using Passage'


### PR DESCRIPTION
- bump gem version

Relates to https://github.com/passageidentity/passage-ruby/pull/11.

This fixes the failed action [here](https://github.com/passageidentity/passage-ruby/runs/7469656932?check_suite_focus=true).