### PR TITLE
Propagate api errors up with PassageError class 

### DIFF
--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -19,8 +19,7 @@ module Passage
         response = @connection.get("/v1/apps/#{@app_id}")
         return response.body["app"]
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           message: "failed to fetch passage app",
           status_code: e.response[:status],
           body: e.response[:body]

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -20,10 +20,10 @@ module Passage
         return response.body["app"]
       rescue Faraday::Error => e
         raise PassageError.new(
-          message: "failed to fetch passage app",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                message: "failed to fetch passage app",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -56,8 +56,7 @@ module Passage
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY
         unless request.cookies["psg_auth_token"].present?
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message:
               `missing authentication token: expected "psg_auth_token" cookie`
           )
@@ -66,8 +65,7 @@ module Passage
       else
         headers = request.headers
         unless headers["Authorization"].present?
-          raise
-          PassageError.new(message: "no authentication token in header")
+          raise PassageError.new(message: "no authentication token in header")
         end
         @token = headers["Authorization"].split(" ").last
       end

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -57,9 +57,9 @@ module Passage
       if @auth_strategy === Passage::COOKIE_STRATEGY
         unless request.cookies["psg_auth_token"].present?
           raise PassageError.new(
-            message:
-              `missing authentication token: expected "psg_auth_token" cookie`
-          )
+                  message:
+                    `missing authentication token: expected "psg_auth_token" cookie`
+                )
         end
         @token = request.cookies["psg_auth_token"]
       else

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -19,7 +19,12 @@ module Passage
         response = @connection.get("/v1/apps/#{@app_id}")
         return response.body["app"]
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new(message: "failed to fetch passage app", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                message: "failed to fetch passage app",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
@@ -51,13 +56,18 @@ module Passage
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY
         unless request.cookies["psg_auth_token"].present?
-          raise PassageError, PassageError.new(message: `missing authentication token: expected "psg_auth_token" cookie`)
+          raise PassageError,
+                PassageError.new(
+                  message:
+                    `missing authentication token: expected "psg_auth_token" cookie`
+                )
         end
         @token = request.cookies["psg_auth_token"]
       else
         headers = request.headers
         unless headers["Authorization"].present?
-          raise PassageError, PassageError.new(message: "no authentication token in header")
+          raise PassageError,
+                PassageError.new(message: "no authentication token in header")
         end
         @token = headers["Authorization"].split(" ").last
       end

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -19,12 +19,12 @@ module Passage
         response = @connection.get("/v1/apps/#{@app_id}")
         return response.body["app"]
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                message: "failed to fetch passage app",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          message: "failed to fetch passage app",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
 
@@ -56,18 +56,18 @@ module Passage
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY
         unless request.cookies["psg_auth_token"].present?
-          raise PassageError,
-                PassageError.new(
-                  message:
-                    `missing authentication token: expected "psg_auth_token" cookie`
-                )
+          raise
+          PassageError.new(
+            message:
+              `missing authentication token: expected "psg_auth_token" cookie`
+          )
         end
         @token = request.cookies["psg_auth_token"]
       else
         headers = request.headers
         unless headers["Authorization"].present?
-          raise PassageError,
-                PassageError.new(message: "no authentication token in header")
+          raise
+          PassageError.new(message: "no authentication token in header")
         end
         @token = headers["Authorization"].split(" ").last
       end
@@ -76,7 +76,7 @@ module Passage
       if @token
         return authenticate_token(@token)
       else
-        raise PassageError, PassageError.new(message: "no authentication token")
+        raise PassageError.new(message: "no authentication token")
       end
       nil
     end
@@ -106,15 +106,15 @@ module Passage
           )
         return claims[0]["sub"]
       rescue JWT::InvalidIssuerError => e
-        raise PassageError, PassageError.new(message: e.message)
+        raise PassageError.new(message: e.message)
       rescue JWT::InvalidAudError => e
-        raise PassageError, PassageError.new(e.message)
+        raise PassageError.new(e.message)
       rescue JWT::ExpiredSignature => e
-        raise PassageError, PassageError.new(e.message)
+        raise PassageError.new(e.message)
       rescue JWT::IncorrectAlgorithm => e
-        raise PassageError, PassageError.new(e.message)
+        raise PassageError.new(e.message)
       rescue JWT::DecodeError => e
-        raise PassageError, PassageError.new(e.message)
+        raise PassageError.new(e.message)
       end
     end
   end

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -165,7 +165,7 @@ module Passage
 
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
-        raise PassageError, PassageError(message: "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL")
+        raise PassageError, PassageError.new(message: "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL")
       end
       magic_link_req["channel"] = channel unless channel.empty?
       magic_link_req["send"] = send

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -165,7 +165,11 @@ module Passage
 
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
-        raise PassageError, PassageError.new(message: "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL")
+        raise PassageError,
+              PassageError.new(
+                message:
+                  "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
+              )
       end
       magic_link_req["channel"] = channel unless channel.empty?
       magic_link_req["send"] = send
@@ -194,7 +198,12 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new(message: "failed to create Passage Magic Link", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                message: "failed to create Passage Magic Link",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
   end

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -77,7 +77,7 @@ module Passage
 
       # check for valid auth strategy
       unless [COOKIE_STRATEGY, HEADER_STRATEGY].include? auth_strategy
-        raise PassageError, "invalid auth strategy."
+        raise PassageError, PassageError.new(message: "invalid auth strategy.")
       end
       @auth_strategy = auth_strategy
 
@@ -165,8 +165,7 @@ module Passage
 
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
-        raise PassageError,
-              "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
+        raise PassageError, PassageError(message: "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL")
       end
       magic_link_req["channel"] = channel unless channel.empty?
       magic_link_req["send"] = send
@@ -195,8 +194,7 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError,
-              "failed to create Passage Magic Link. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+        raise PassageError, PassageError.new(message: "failed to create Passage Magic Link", status_code: e.response[:status], body: e.response[:body])
       end
     end
   end

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -199,10 +199,10 @@ module Passage
         )
       rescue Faraday::Error => e
         raise PassageError.new(
-          message: "failed to create Passage Magic Link",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                message: "failed to create Passage Magic Link",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
   end

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -198,8 +198,7 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           message: "failed to create Passage Magic Link",
           status_code: e.response[:status],
           body: e.response[:body]

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -165,8 +165,7 @@ module Passage
 
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
-        raise
-        PassageError.new(
+        raise PassageError.new(
           message:
             "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
         )

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -77,7 +77,7 @@ module Passage
 
       # check for valid auth strategy
       unless [COOKIE_STRATEGY, HEADER_STRATEGY].include? auth_strategy
-        raise PassageError, PassageError.new(message: "invalid auth strategy.")
+        raise PassageError.new(message: "invalid auth strategy.")
       end
       @auth_strategy = auth_strategy
 
@@ -165,11 +165,11 @@ module Passage
 
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
-        raise PassageError,
-              PassageError.new(
-                message:
-                  "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
-              )
+        raise
+        PassageError.new(
+          message:
+            "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
+        )
       end
       magic_link_req["channel"] = channel unless channel.empty?
       magic_link_req["send"] = send
@@ -198,12 +198,12 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                message: "failed to create Passage Magic Link",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          message: "failed to create Passage Magic Link",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
   end

--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -166,9 +166,9 @@ module Passage
       # check to see if the channel specified is valid before sending it off to the server
       unless [PHONE_CHANNEL, EMAIL_CHANNEL].include? channel
         raise PassageError.new(
-          message:
-            "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
-        )
+                message:
+                  "channel: must be either Passage::EMAIL_CHANNEL or Passage::PHONE_CHANNEL"
+              )
       end
       magic_link_req["channel"] = channel unless channel.empty?
       magic_link_req["send"] = send

--- a/lib/passageidentity/error.rb
+++ b/lib/passageidentity/error.rb
@@ -1,4 +1,17 @@
+require "net/http"
+
 module Passage
   class PassageError < StandardError
+    attr_reader :status_code
+    attr_reader :status_text
+    attr_reader :message
+    attr_reader :error
+
+    def initialize(message:, status_code: nil, body: nil)
+      @message = message
+      @status_code =  status_code
+      @status_text = status_code.nil? ? nil : Net::HTTPResponse::CODE_TO_OBJ[status_code.to_s]
+      @error = body.nil? ? nil :  body["error"]
+     end
   end
 end

--- a/lib/passageidentity/error.rb
+++ b/lib/passageidentity/error.rb
@@ -9,9 +9,16 @@ module Passage
 
     def initialize(message:, status_code: nil, body: nil)
       @message = message
-      @status_code =  status_code
-      @status_text = status_code.nil? ? nil : Net::HTTPResponse::CODE_TO_OBJ[status_code.to_s]
-      @error = body.nil? ? nil :  body["error"]
-     end
+      @status_code = status_code
+      @status_text =
+        (
+          if status_code.nil?
+            nil
+          else
+            Net::HTTPResponse::CODE_TO_OBJ[status_code.to_s]
+          end
+        )
+      @error = body.nil? ? nil : body["error"]
+    end
   end
 end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -319,6 +319,7 @@ module Passage
     end
 
     private
+
     def user_exists?(user_id)
       if user_id.to_s.empty?
         raise PassageError, PassageError.new("must supply a valid user_id")

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -10,7 +10,7 @@ module Passage
     end
 
     def get(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response = @connection.get("/v1/apps/#{@app_id}/users/#{user_id}")
         user = response.body["user"]
@@ -35,17 +35,15 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                "passage User with ID \"#{user_id}\" does not exist"
+          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError,
-                "failed to get Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+          raise PassageError, PassageError(message: "failed to get Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
 
     def activate(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/activate")
@@ -70,17 +68,15 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                "passage User with ID \"#{user_id}\" does not exist"
+          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError,
-                "failed to activate Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+          raise PassageError, PassageError(message: "failed to activate Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
 
     def deactivate(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/deactivate")
@@ -105,17 +101,15 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                "passage User with ID \"#{user_id}\" does not exist"
+          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError,
-                "failed to deactivate Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+          raise PassageError, PassageError(message: "failed to deactivate Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
 
     def update(user_id:, email: "", phone: "", user_metadata: {})
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       updates = {}
       updates["email"] = email unless email.empty?
       updates["phone"] = phone unless phone.empty?
@@ -144,11 +138,9 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                "passage User with ID \"#{user_id}\" does not exist"
+          raise PassageError, PassageError.new("passage User with ID \"#{user_id}\" does not exist")
         else
-          raise PassageError,
-                "failed to update Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+          raise PassageError, PassageError.new("failed to update Passage User", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
@@ -180,29 +172,26 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError,
-              "failed to create Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+        raise PassageError, PassageError.new("failed to create Passage User", status_code: e.response[:status], body: e.response[:body])
       end
     end
 
     def delete(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response = @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}")
         return true
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                "passage User with ID \"#{user_id}\" does not exist"
+          raise PassageError, PassageError.new("passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError,
-                "failed to delete Passage User. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+          raise PassageError, PassageError.new("failed to delete Passage User", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
 
     def delete_device(user_id:, device_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       if device_id.to_s.empty?
         raise PassageError, "must supply a valid device_id"
       end
@@ -213,13 +202,12 @@ module Passage
           )
         return true
       rescue Faraday::Error => e
-        raise PassageError,
-              "failed to delete Passage User Device. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+        raise PassageError, PassageError.new("failed to delete Passage User Device", status_code: e.response[:status], body: e.response[:body])
       end
     end
 
     def list_devices(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response =
           @connection.get("/v1/apps/#{@app_id}/users/#{user_id}/devices")
@@ -240,20 +228,18 @@ module Passage
         end
         return devices
       rescue Faraday::Error => e
-        raise PassageError,
-              "failed to delete Passage User Device. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+        raise PassageError, PassageError.new("failed to delete Passage User Device", status_code: e.response[:status], body: e.response[:body])
       end
     end
 
     def signout(user_id:)
-      raise PassageError, "must supply a valid user_id" if user_id.to_s.empty?
+      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
       begin
         response =
           @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}/tokens/")
         return true
       rescue Faraday::Error => e
-        raise PassageError,
-              "failed to revoke user's refresh tokens. Http Status: #{e.response[:status]}. Response: #{e.response[:body]["error"]}"
+        raise PassageError, PassageError.new("failed to revoke user's refresh tokens", status_code: e.response[:status], body: e.response[:body])
       end
     end
   end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -291,7 +291,6 @@ module Passage
 
     def signout(user_id:)
       user_exists?(user_id)
-      end
       begin
         response =
           @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}/tokens/")

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -36,15 +36,13 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "Passage User with ID \"#{user_id}\" does not exist",
             status_code: e.response[:status],
             body: e.response[:body]
           )
         else
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "failed to get Passage User.",
             status_code: e.response[:status],
             body: e.response[:body]
@@ -80,15 +78,13 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "Passage User with ID \"#{user_id}\" does not exist",
             status_code: e.response[:status],
             body: e.response[:body]
           )
         else
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "failed to activate Passage User.",
             status_code: e.response[:status],
             body: e.response[:body]
@@ -124,15 +120,13 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "Passage User with ID \"#{user_id}\" does not exist",
             status_code: e.response[:status],
             body: e.response[:body]
           )
         else
-          raise
-          PassageError.new(
+          raise PassageError.new(
             message: "failed to deactivate Passage User.",
             status_code: e.response[:status],
             body: e.response[:body]
@@ -172,11 +166,13 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise
-          PassageError.new("passage User with ID \"#{user_id}\" does not exist")
+          raise PassageError.new(
+            message: "Passage User with ID \"#{user_id}\" does not exist",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         else
-          raise
-          PassageError.new(
+          raise PassageError.new(
             "failed to update Passage User",
             status_code: e.response[:status],
             body: e.response[:body]
@@ -212,8 +208,7 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           "failed to create Passage User",
           status_code: e.response[:status],
           body: e.response[:body]
@@ -229,15 +224,13 @@ module Passage
         return true
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise
-          PassageError.new(
+          raise PassageError.new(
             "passage User with ID \"#{user_id}\" does not exist",
             status_code: e.response[:status],
             body: e.response[:body]
           )
         else
-          raise
-          PassageError.new(
+          raise PassageError.new(
             "failed to delete Passage User",
             status_code: e.response[:status],
             body: e.response[:body]
@@ -257,8 +250,7 @@ module Passage
           )
         return true
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           "failed to delete Passage User Device",
           status_code: e.response[:status],
           body: e.response[:body]
@@ -289,8 +281,7 @@ module Passage
         end
         return devices
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           "failed to delete Passage User Device",
           status_code: e.response[:status],
           body: e.response[:body]
@@ -307,8 +298,7 @@ module Passage
           @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}/tokens/")
         return true
       rescue Faraday::Error => e
-        raise
-        PassageError.new(
+        raise PassageError.new(
           "failed to revoke user's refresh tokens",
           status_code: e.response[:status],
           body: e.response[:body]

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -36,19 +36,19 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                PassageError.new(
-                  message: "Passage User with ID \"#{user_id}\" does not exist",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "Passage User with ID \"#{user_id}\" does not exist",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         else
-          raise PassageError,
-                PassageError.new(
-                  message: "failed to get Passage User.",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "failed to get Passage User.",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         end
       end
     end
@@ -80,19 +80,19 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                PassageError.new(
-                  message: "Passage User with ID \"#{user_id}\" does not exist",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "Passage User with ID \"#{user_id}\" does not exist",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         else
-          raise PassageError,
-                PassageError.new(
-                  message: "failed to activate Passage User.",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "failed to activate Passage User.",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         end
       end
     end
@@ -124,19 +124,19 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                PassageError.new(
-                  message: "Passage User with ID \"#{user_id}\" does not exist",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "Passage User with ID \"#{user_id}\" does not exist",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         else
-          raise PassageError,
-                PassageError.new(
-                  message: "failed to deactivate Passage User.",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            message: "failed to deactivate Passage User.",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         end
       end
     end
@@ -172,17 +172,15 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                PassageError.new(
-                  "passage User with ID \"#{user_id}\" does not exist"
-                )
+          raise
+          PassageError.new("passage User with ID \"#{user_id}\" does not exist")
         else
-          raise PassageError,
-                PassageError.new(
-                  "failed to update Passage User",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            "failed to update Passage User",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         end
       end
     end
@@ -214,12 +212,12 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                "failed to create Passage User",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          "failed to create Passage User",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
 
@@ -231,19 +229,19 @@ module Passage
         return true
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError,
-                PassageError.new(
-                  "passage User with ID \"#{user_id}\" does not exist",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            "passage User with ID \"#{user_id}\" does not exist",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         else
-          raise PassageError,
-                PassageError.new(
-                  "failed to delete Passage User",
-                  status_code: e.response[:status],
-                  body: e.response[:body]
-                )
+          raise
+          PassageError.new(
+            "failed to delete Passage User",
+            status_code: e.response[:status],
+            body: e.response[:body]
+          )
         end
       end
     end
@@ -259,12 +257,12 @@ module Passage
           )
         return true
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                "failed to delete Passage User Device",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          "failed to delete Passage User Device",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
 
@@ -291,30 +289,30 @@ module Passage
         end
         return devices
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                "failed to delete Passage User Device",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          "failed to delete Passage User Device",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
 
     def signout(user_id:)
       if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
+        raise PassageError.new("must supply a valid user_id")
       end
       begin
         response =
           @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}/tokens/")
         return true
       rescue Faraday::Error => e
-        raise PassageError,
-              PassageError.new(
-                "failed to revoke user's refresh tokens",
-                status_code: e.response[:status],
-                body: e.response[:body]
-              )
+        raise
+        PassageError.new(
+          "failed to revoke user's refresh tokens",
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
       end
     end
 
@@ -322,13 +320,13 @@ module Passage
 
     def user_exists?(user_id)
       if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
+        raise PassageError.new("must supply a valid user_id")
       end
     end
 
     def device_exists?(device_id)
       if device_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid device_id")
+        raise PassageError.new("must supply a valid device_id")
       end
     end
   end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -290,8 +290,7 @@ module Passage
     end
 
     def signout(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError.new("must supply a valid user_id")
+      user_exists?(user_id)
       end
       begin
         response =
@@ -310,13 +309,13 @@ module Passage
 
     def user_exists?(user_id)
       if user_id.to_s.empty?
-        raise PassageError.new("must supply a valid user_id")
+        raise PassageError.new(message: "must supply a valid user_id")
       end
     end
 
     def device_exists?(device_id)
       if device_id.to_s.empty?
-        raise PassageError.new("must supply a valid device_id")
+        raise PassageError.new(message: "must supply a valid device_id")
       end
     end
   end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -37,16 +37,16 @@ module Passage
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
           raise PassageError.new(
-            message: "Passage User with ID \"#{user_id}\" does not exist",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
           raise PassageError.new(
-            message: "failed to get Passage User.",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "failed to get Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -79,16 +79,16 @@ module Passage
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
           raise PassageError.new(
-            message: "Passage User with ID \"#{user_id}\" does not exist",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
           raise PassageError.new(
-            message: "failed to activate Passage User.",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "failed to activate Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -121,16 +121,16 @@ module Passage
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
           raise PassageError.new(
-            message: "Passage User with ID \"#{user_id}\" does not exist",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
           raise PassageError.new(
-            message: "failed to deactivate Passage User.",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "failed to deactivate Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -167,16 +167,16 @@ module Passage
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
           raise PassageError.new(
-            message: "Passage User with ID \"#{user_id}\" does not exist",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
           raise PassageError.new(
-            "failed to update Passage User",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  "failed to update Passage User",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -209,10 +209,10 @@ module Passage
         )
       rescue Faraday::Error => e
         raise PassageError.new(
-          "failed to create Passage User",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                "failed to create Passage User",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
@@ -225,16 +225,16 @@ module Passage
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
           raise PassageError.new(
-            "passage User with ID \"#{user_id}\" does not exist",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  "passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
           raise PassageError.new(
-            "failed to delete Passage User",
-            status_code: e.response[:status],
-            body: e.response[:body]
-          )
+                  "failed to delete Passage User",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -251,10 +251,10 @@ module Passage
         return true
       rescue Faraday::Error => e
         raise PassageError.new(
-          "failed to delete Passage User Device",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                "failed to delete Passage User Device",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
@@ -282,10 +282,10 @@ module Passage
         return devices
       rescue Faraday::Error => e
         raise PassageError.new(
-          "failed to delete Passage User Device",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                "failed to delete Passage User Device",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
@@ -299,10 +299,10 @@ module Passage
         return true
       rescue Faraday::Error => e
         raise PassageError.new(
-          "failed to revoke user's refresh tokens",
-          status_code: e.response[:status],
-          body: e.response[:body]
-        )
+                "failed to revoke user's refresh tokens",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -35,9 +35,9 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError, PassageError(message: "failed to get Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "failed to get Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
@@ -68,9 +68,9 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError, PassageError(message: "failed to activate Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "failed to activate Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end
@@ -101,9 +101,9 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
         else
-          raise PassageError, PassageError(message: "failed to deactivate Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError, PassageError.new(message: "failed to deactivate Passage User.", status_code: e.response[:status], body: e.response[:body])
         end
       end
     end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -10,9 +10,8 @@ module Passage
     end
 
     def get(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       begin
         response = @connection.get("/v1/apps/#{@app_id}/users/#{user_id}")
         user = response.body["user"]
@@ -55,9 +54,8 @@ module Passage
     end
 
     def activate(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/activate")
@@ -100,9 +98,8 @@ module Passage
     end
 
     def deactivate(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/deactivate")
@@ -145,9 +142,8 @@ module Passage
     end
 
     def update(user_id:, email: "", phone: "", user_metadata: {})
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       updates = {}
       updates["email"] = email unless email.empty?
       updates["phone"] = phone unless phone.empty?
@@ -228,9 +224,8 @@ module Passage
     end
 
     def delete(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       begin
         response = @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}")
         return true
@@ -254,12 +249,9 @@ module Passage
     end
 
     def delete_device(user_id:, device_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
-      if device_id.to_s.empty?
-        raise PassageError, "must supply a valid device_id"
-      end
+      user_exists?(user_id)
+      device_exists?(device_id)
+
       begin
         response =
           @connection.delete(
@@ -277,9 +269,8 @@ module Passage
     end
 
     def list_devices(user_id:)
-      if user_id.to_s.empty?
-        raise PassageError, PassageError.new("must supply a valid user_id")
-      end
+      user_exists?(user_id)
+
       begin
         response =
           @connection.get("/v1/apps/#{@app_id}/users/#{user_id}/devices")
@@ -324,6 +315,19 @@ module Passage
                 status_code: e.response[:status],
                 body: e.response[:body]
               )
+      end
+    end
+
+    private
+    def user_exists?(user_id:)
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
+    end
+
+    def device_exists?(device_id:)
+      if device_id.to_s.empty?
+        raise PassageError, "must supply a valid device_id"
       end
     end
   end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -10,7 +10,9 @@ module Passage
     end
 
     def get(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response = @connection.get("/v1/apps/#{@app_id}/users/#{user_id}")
         user = response.body["user"]
@@ -35,15 +37,27 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
-          raise PassageError, PassageError.new(message: "failed to get Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "failed to get Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
 
     def activate(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/activate")
@@ -68,15 +82,27 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
-          raise PassageError, PassageError.new(message: "failed to activate Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "failed to activate Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
 
     def deactivate(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response =
           @connection.patch("/v1/apps/#{@app_id}/users/#{user_id}/deactivate")
@@ -101,15 +127,27 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError.new(message: "Passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "Passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
-          raise PassageError, PassageError.new(message: "failed to deactivate Passage User.", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  message: "failed to deactivate Passage User.",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
 
     def update(user_id:, email: "", phone: "", user_metadata: {})
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       updates = {}
       updates["email"] = email unless email.empty?
       updates["phone"] = phone unless phone.empty?
@@ -138,9 +176,17 @@ module Passage
         )
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError.new("passage User with ID \"#{user_id}\" does not exist")
+          raise PassageError,
+                PassageError.new(
+                  "passage User with ID \"#{user_id}\" does not exist"
+                )
         else
-          raise PassageError, PassageError.new("failed to update Passage User", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  "failed to update Passage User",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
@@ -172,26 +218,45 @@ module Passage
           )
         )
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new("failed to create Passage User", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                "failed to create Passage User",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
     def delete(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response = @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}")
         return true
       rescue Faraday::Error => e
         if e.is_a? Faraday::ResourceNotFound
-          raise PassageError, PassageError.new("passage User with ID \"#{user_id}\" does not exist", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  "passage User with ID \"#{user_id}\" does not exist",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         else
-          raise PassageError, PassageError.new("failed to delete Passage User", status_code: e.response[:status], body: e.response[:body])
+          raise PassageError,
+                PassageError.new(
+                  "failed to delete Passage User",
+                  status_code: e.response[:status],
+                  body: e.response[:body]
+                )
         end
       end
     end
 
     def delete_device(user_id:, device_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       if device_id.to_s.empty?
         raise PassageError, "must supply a valid device_id"
       end
@@ -202,12 +267,19 @@ module Passage
           )
         return true
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new("failed to delete Passage User Device", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                "failed to delete Passage User Device",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
     def list_devices(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response =
           @connection.get("/v1/apps/#{@app_id}/users/#{user_id}/devices")
@@ -228,18 +300,30 @@ module Passage
         end
         return devices
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new("failed to delete Passage User Device", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                "failed to delete Passage User Device",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
 
     def signout(user_id:)
-      raise PassageError, PassageError.new("must supply a valid user_id") if user_id.to_s.empty?
+      if user_id.to_s.empty?
+        raise PassageError, PassageError.new("must supply a valid user_id")
+      end
       begin
         response =
           @connection.delete("/v1/apps/#{@app_id}/users/#{user_id}/tokens/")
         return true
       rescue Faraday::Error => e
-        raise PassageError, PassageError.new("failed to revoke user's refresh tokens", status_code: e.response[:status], body: e.response[:body])
+        raise PassageError,
+              PassageError.new(
+                "failed to revoke user's refresh tokens",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
       end
     end
   end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -319,15 +319,15 @@ module Passage
     end
 
     private
-    def user_exists?(user_id:)
+    def user_exists?(user_id)
       if user_id.to_s.empty?
         raise PassageError, PassageError.new("must supply a valid user_id")
       end
     end
 
-    def device_exists?(device_id:)
+    def device_exists?(device_id)
       if device_id.to_s.empty?
-        raise PassageError, "must supply a valid device_id"
+        raise PassageError, PassageError.new("must supply a valid device_id")
       end
     end
   end

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'passageidentity'
-  s.version = '0.1.2'
+  s.version = '0.2.0'
   s.summary = 'Passage SDK for biometric authentication'
   s.description =
     'Enables verification of server-side authentication and user management for applications using Passage'

--- a/tests/errors_test.rb
+++ b/tests/errors_test.rb
@@ -1,0 +1,26 @@
+require_relative "../lib/passageidentity/error"
+require "test/unit"
+require "net/http"
+
+class ErrorTest < Test::Unit::TestCase
+  def test_initialize
+    body = {"error" => "some error"}
+
+    error = Passage::PassageError.new(message: "some message", status_code: 400, body: body)
+
+    assert_equal error.message, "some message"
+    assert_equal error.error, "some error"
+    assert_equal error.status_code, 400
+    assert_equal error.status_text, Net::HTTPBadRequest
+  end
+
+  def test_initialize_message_only
+    error = Passage::PassageError.new(message: "some message")
+
+    assert_equal error.message, "some message"
+    assert_equal error.error, nil
+    assert_equal error.status_code, nil
+    assert_equal error.status_text, nil
+  end
+
+end

--- a/tests/errors_test.rb
+++ b/tests/errors_test.rb
@@ -4,9 +4,14 @@ require "net/http"
 
 class ErrorTest < Test::Unit::TestCase
   def test_initialize
-    body = {"error" => "some error"}
+    body = { "error" => "some error" }
 
-    error = Passage::PassageError.new(message: "some message", status_code: 400, body: body)
+    error =
+      Passage::PassageError.new(
+        message: "some message",
+        status_code: 400,
+        body: body
+      )
 
     assert_equal error.message, "some message"
     assert_equal error.error, "some error"
@@ -22,5 +27,4 @@ class ErrorTest < Test::Unit::TestCase
     assert_equal error.status_code, nil
     assert_equal error.status_text, nil
   end
-
 end


### PR DESCRIPTION
PassageError class now containes these fields:
`message` -> descriptive information regarding the error from the sdk
`status_code` (optional) -> api status code from an API request to the passage backend
`status_text` (optional) -> api status text from an API request to the passage backend
`error` (optional) -> api descriptive error from an API request to the passage backend