### PR TITLE
Psg 1301 sdk tests to test both header and cookie auth for all sdks

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run Tests
       run: |
         gem build passageidentity.gemspec -o test.gem
-        gem install test.gem
+        gem install test.gem --development
         rm test.gem
         ruby tests/all.rb
     - name: Run Linting

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.1.2'
 
     - name: Run Tests
       run: |

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1.2'
+        ruby-version: '3.1'
 
     - name: Run Tests
       run: |

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
   workflow_dispatch:
   pull_request:
-    branches: 
+    branches:
       - main
 
 env:
@@ -25,9 +25,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        gem build passageidentity.gemspec -o test.gem
-        gem install test.gem --development
-        rm test.gem
+        bundle install
         ruby tests/all.rb
     - name: Run Linting
       run: |

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1'
 
     - name: Run Tests
       run: |

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -30,5 +30,4 @@ jobs:
     - name: Run Linting
       run: |
         npm install -g prettier @prettier/plugin-ruby
-        gem install bundler prettier_print syntax_tree syntax_tree-haml syntax_tree-rbs
         prettier --check '**/*.rb'

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,8 @@ gemspec
 group :development do
   gem 'rack'
   gem 'dotenv'
+  gem 'prettier_print'
+  gem 'syntax_tree'
+  gem 'syntax_tree-haml'
+  gem 'syntax_tree-rbs'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in auth0.gemspec
+gemspec
+
+group :development do
+  gem 'rack'
+  gem 'dotenv'
+end

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -83,10 +83,10 @@ module Passage
         kid = JWT.decode(token, nil, false)[1]["kid"]
         exists = false
         for jwk in @jwks["keys"]
-            if jwk["kid"] == kid
+          if jwk["kid"] == kid
             exists = true
             break
-            end
+          end
         end
         fetch_jwks unless exists
         claims =

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -54,16 +54,16 @@ module Passage
     def authenticate_request(request)
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY
-        unless request.cookies["psg_auth_token"].present?
+        unless request.cookies.key?("psg_auth_token")
           raise PassageError.new(
                   message:
-                    `missing authentication token: expected "psg_auth_token" cookie`
+                    "missing authentication token: expected \"psg_auth_token\" cookie"
                 )
         end
         @token = request.cookies["psg_auth_token"]
       else
         headers = request.headers
-        unless headers["Authorization"].present?
+        unless headers.key?("Authorization")
           raise PassageError.new(message: "no authentication token in header")
         end
         @token = headers["Authorization"].split(" ").last
@@ -79,16 +79,16 @@ module Passage
     end
 
     def authenticate_token(token)
-      kid = JWT.decode(token, nil, false)[1]["kid"]
-      exists = false
-      for jwk in @jwks["keys"]
-        if jwk["kid"] == kid
-          exists = true
-          break
-        end
-      end
-      fetch_jwks unless exists
       begin
+        kid = JWT.decode(token, nil, false)[1]["kid"]
+        exists = false
+        for jwk in @jwks["keys"]
+            if jwk["kid"] == kid
+            exists = true
+            break
+            end
+        end
+        fetch_jwks unless exists
         claims =
           JWT.decode(
             token,
@@ -105,13 +105,13 @@ module Passage
       rescue JWT::InvalidIssuerError => e
         raise PassageError.new(message: e.message)
       rescue JWT::InvalidAudError => e
-        raise PassageError.new(e.message)
+        raise PassageError.new(message: e.message)
       rescue JWT::ExpiredSignature => e
-        raise PassageError.new(e.message)
+        raise PassageError.new(message: e.message)
       rescue JWT::IncorrectAlgorithm => e
-        raise PassageError.new(e.message)
+        raise PassageError.new(message: e.message)
       rescue JWT::DecodeError => e
-        raise PassageError.new(e.message)
+        raise PassageError.new(message: e.message)
       end
     end
   end

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -27,6 +27,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
   s.add_dependency 'jwt', '~> 2.3', '>= 2.3.0'
   s.add_dependency 'openssl', '~> 3.0', '>= 3.0.0'
-  s.add_development_dependency 'rack', '~> 3.0', '>= 3.0.0'
-  s.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.6'
 end

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
     end
 
   s.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
-  s.add_development_dependency 'rack', '>= 3.0.0'
-  s.add_dependency 'jwt', '>= 2.3.0'
-  s.add_dependency 'openssl', '>= 3.0.0'
-  s.add_dependency 'dotenv', '>= 2.7.6'
+  s.add_dependency 'jwt', '~> 2.3', '>= 2.3.0'
+  s.add_dependency 'openssl', '~> 3.0', '>= 3.0.0'
+  s.add_development_dependency 'rack', '~> 3.0', '>= 3.0.0'
+  s.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.6'
 end

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     end
 
   s.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
-  s.add_dependency 'rack', '>= 3.0.0'
+  s.add_development_dependency 'rack', '>= 3.0.0'
   s.add_dependency 'jwt', '>= 2.3.0'
   s.add_dependency 'openssl', '>= 3.0.0'
   s.add_dependency 'dotenv', '>= 2.7.6'

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     end
 
   s.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
+  s.add_dependency 'rack', '>= 3.0.0'
   s.add_dependency 'jwt', '>= 2.3.0'
   s.add_dependency 'openssl', '>= 3.0.0'
   s.add_dependency 'dotenv', '>= 2.7.6'

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'passageidentity'
-  s.version = '0.2.1'
+  s.version = '0.2.2'
   s.summary = 'Passage SDK for biometric authentication'
   s.description =
     'Enables verification of server-side authentication and user management for applications using Passage'

--- a/tests/auth_test.rb
+++ b/tests/auth_test.rb
@@ -7,9 +7,59 @@ Dotenv.load(".env")
 class TestUserAPI < Test::Unit::TestCase
   PassageClient =
     Passage::Client.new(app_id: ENV["APP_ID"], api_key: ENV["API_KEY"])
+  PassageHeaderClient = 
+    Passage::Client.new(app_id: ENV["APP_ID"], api_key: ENV["API_KEY"], auth_strategy: Passage::HEADER_STRATEGY)
 
-  def test_authenticate_token
+  def test_valid_authenticate_token
     user_id = PassageClient.auth.authenticate_token(ENV["PSG_JWT"])
     assert_equal ENV["TEST_USER_ID"], user_id
+  end
+
+  def test_invalid_authenticate_token
+    assert_raises Passage::PassageError do
+        PassageClient.auth.authenticate_token("invalid_token")
+    end
+  end
+  
+  def test_valid_authenticate_request_cookie
+    env = Rack::MockRequest.env_for("https://test.com")
+    env["HTTP_COOKIE"] = "psg_auth_token=#{ENV["PSG_JWT"]}"
+    cookie_request = Rack::Request.new(env) 
+    user_id = PassageClient.auth.authenticate_request(cookie_request)
+    assert_equal ENV["TEST_USER_ID"], user_id
+
+  end
+
+  def test_invalid_authenticate_request_cookie
+    envBadCookie = Rack::MockRequest.env_for("https://test.com")
+    envBadCookie["HTTP_COOKIE"] = "psg_auth_token=invalid_token}"
+    bad_cookie_request = Rack::Request.new(envBadCookie) 
+    assert_raises Passage::PassageError do
+        PassageClient.auth.authenticate_request(bad_cookie_request)
+    end
+    no_cookie_request = Rack::Request.new({}) 
+    assert_raises Passage::PassageError do
+        PassageClient.auth.authenticate_request(no_cookie_request)
+    end
+  end
+  
+  def test_valid_authenticate_request_header
+    headers = {"Authorization" => "Bearer #{ENV["PSG_JWT"]}"}
+    header_request = Faraday.new(url: "https://test.com", headers: headers) 
+    user_id = PassageHeaderClient.auth.authenticate_request(header_request)
+    assert_equal ENV["TEST_USER_ID"], user_id
+
+  end
+
+  def test_invalid_authenticate_request_header
+    invalid_headers = {"Authorization" => "Bearer invalid_token"}
+    no_header_request = Faraday.new(url: "https://test.com") 
+    assert_raises Passage::PassageError do
+        PassageHeaderClient.auth.authenticate_request(no_header_request)
+    end
+    invalid_header_request = Faraday.new(url: "https://test.com", headers: invalid_headers) 
+    assert_raises Passage::PassageError do
+        PassageHeaderClient.auth.authenticate_request(no_header_request)
+    end
   end
 end

--- a/tests/auth_test.rb
+++ b/tests/auth_test.rb
@@ -7,8 +7,12 @@ Dotenv.load(".env")
 class TestUserAPI < Test::Unit::TestCase
   PassageClient =
     Passage::Client.new(app_id: ENV["APP_ID"], api_key: ENV["API_KEY"])
-  PassageHeaderClient = 
-    Passage::Client.new(app_id: ENV["APP_ID"], api_key: ENV["API_KEY"], auth_strategy: Passage::HEADER_STRATEGY)
+  PassageHeaderClient =
+    Passage::Client.new(
+      app_id: ENV["APP_ID"],
+      api_key: ENV["API_KEY"],
+      auth_strategy: Passage::HEADER_STRATEGY
+    )
 
   def test_valid_authenticate_token
     user_id = PassageClient.auth.authenticate_token(ENV["PSG_JWT"])
@@ -17,49 +21,48 @@ class TestUserAPI < Test::Unit::TestCase
 
   def test_invalid_authenticate_token
     assert_raises Passage::PassageError do
-        PassageClient.auth.authenticate_token("invalid_token")
+      PassageClient.auth.authenticate_token("invalid_token")
     end
   end
-  
+
   def test_valid_authenticate_request_cookie
     env = Rack::MockRequest.env_for("https://test.com")
     env["HTTP_COOKIE"] = "psg_auth_token=#{ENV["PSG_JWT"]}"
-    cookie_request = Rack::Request.new(env) 
+    cookie_request = Rack::Request.new(env)
     user_id = PassageClient.auth.authenticate_request(cookie_request)
     assert_equal ENV["TEST_USER_ID"], user_id
-
   end
 
   def test_invalid_authenticate_request_cookie
     envBadCookie = Rack::MockRequest.env_for("https://test.com")
     envBadCookie["HTTP_COOKIE"] = "psg_auth_token=invalid_token}"
-    bad_cookie_request = Rack::Request.new(envBadCookie) 
+    bad_cookie_request = Rack::Request.new(envBadCookie)
     assert_raises Passage::PassageError do
-        PassageClient.auth.authenticate_request(bad_cookie_request)
+      PassageClient.auth.authenticate_request(bad_cookie_request)
     end
-    no_cookie_request = Rack::Request.new({}) 
+    no_cookie_request = Rack::Request.new({})
     assert_raises Passage::PassageError do
-        PassageClient.auth.authenticate_request(no_cookie_request)
+      PassageClient.auth.authenticate_request(no_cookie_request)
     end
   end
-  
+
   def test_valid_authenticate_request_header
-    headers = {"Authorization" => "Bearer #{ENV["PSG_JWT"]}"}
-    header_request = Faraday.new(url: "https://test.com", headers: headers) 
+    headers = { "Authorization" => "Bearer #{ENV["PSG_JWT"]}" }
+    header_request = Faraday.new(url: "https://test.com", headers: headers)
     user_id = PassageHeaderClient.auth.authenticate_request(header_request)
     assert_equal ENV["TEST_USER_ID"], user_id
-
   end
 
   def test_invalid_authenticate_request_header
-    invalid_headers = {"Authorization" => "Bearer invalid_token"}
-    no_header_request = Faraday.new(url: "https://test.com") 
+    invalid_headers = { "Authorization" => "Bearer invalid_token" }
+    no_header_request = Faraday.new(url: "https://test.com")
     assert_raises Passage::PassageError do
-        PassageHeaderClient.auth.authenticate_request(no_header_request)
+      PassageHeaderClient.auth.authenticate_request(no_header_request)
     end
-    invalid_header_request = Faraday.new(url: "https://test.com", headers: invalid_headers) 
+    invalid_header_request =
+      Faraday.new(url: "https://test.com", headers: invalid_headers)
     assert_raises Passage::PassageError do
-        PassageHeaderClient.auth.authenticate_request(no_header_request)
+      PassageHeaderClient.auth.authenticate_request(no_header_request)
     end
   end
 end

--- a/tests/auth_test.rb
+++ b/tests/auth_test.rb
@@ -1,6 +1,7 @@
 require_relative "../lib/passageidentity/client"
 require "dotenv"
 require "faraday"
+require "rack"
 require "test/unit"
 
 Dotenv.load(".env")


### PR DESCRIPTION
add full authentication tests in auth_test.rb
 - invalid/valid request with cookies and headers
 - invalid/valid authenticate token
 
 In auth_test.rb I am using two different requests to mimic Rails ActionDispatch::Request
 
 ActionDispatch::Request has two functions that I need to replicate `.headers` and `.cookies`
 
 I use Faraday::Request when I need `.headers` and I use Rack:Request when i need `.cookies`