### PR TITLE
Use a version constant instead of parsing gemspec

### DIFF
--- a/lib/passageidentity/client.rb
+++ b/lib/passageidentity/client.rb
@@ -3,6 +3,7 @@
 require_relative "auth"
 require_relative "user_api"
 require_relative "error"
+require_relative "version"
 require "rubygems"
 
 module Passage
@@ -96,9 +97,7 @@ module Passage
     end
 
     def get_connection
-      gemspec = File.join(__dir__, "../../passageidentity.gemspec")
-      spec = Gem::Specification.load(gemspec)
-      headers = { "Passage-Version" => "passage-ruby #{spec.version}" }
+      headers = { "Passage-Version" => "passage-ruby #{Passage::VERSION}" }
       headers["Authorization"] = "Bearer #{@api_key}" if @api_key != ""
 
       @connection =

--- a/lib/passageidentity/version.rb
+++ b/lib/passageidentity/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Passage
+  VERSION = '0.2.3'
+end

--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -1,6 +1,8 @@
+require_relative 'lib/passageidentity/version'
+
 Gem::Specification.new do |s|
   s.name = 'passageidentity'
-  s.version = '0.2.3'
+  s.version = Passage::VERSION
   s.summary = 'Passage SDK for biometric authentication'
   s.description =
     'Enables verification of server-side authentication and user management for applications using Passage'


### PR DESCRIPTION
## Issue

When deploying an application to a container that doesn't contain `git` the passage client throws an error when trying to add the version number to the header.

https://github.com/passageidentity/passage-ruby/blob/3bd08db1743a755ec2b4ae1680efe20f8eda1222/lib/passageidentity/client.rb#L99-L101

This line calls out to the shell to run the `git ls-files` command:
 
https://github.com/passageidentity/passage-ruby/blob/3bd08db1743a755ec2b4ae1680efe20f8eda1222/passageidentity.gemspec#L22

### Error

```ruby
(ruby) spec = Gem::Specification.load(gemspec)
Invalid gemspec in [/app/vendor/bundle/ruby/3.2.0/gems/passageidentity-0.2.3/lib/passageidentity/../../passageidentity.gemspec]:
No such file or directory - git
```

## Solution

This PR changes this project to use the more standard RubyGems approach to have a `VERSION` constant defined and loaded in the gemspec. I've tested my fork on my application and it seems to work as expected.