### PR TITLE
Create `validate_jwt` and deprecate `authenticate_request`

### DIFF
--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -55,6 +55,8 @@ module Passage
     end
 
     def authenticate_request(request)
+      warn "[DEPRECATION] `authenticate_request` is deprecated.  Please use `validate_jwt(token)` instead."
+
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY
         unless request.cookies.key?("psg_auth_token")
@@ -79,6 +81,14 @@ module Passage
         raise PassageError.new(message: "no authentication token")
       end
       nil
+    end
+
+    def validate_jwt(token)
+      if token
+        return authenticate_token(token)
+      else
+        raise PassageError.new(message: "no authentication token")
+      end
     end
 
     def authenticate_token(token)

--- a/tests/auth_test.rb
+++ b/tests/auth_test.rb
@@ -15,6 +15,11 @@ class TestAuthAPI < Test::Unit::TestCase
       auth_strategy: Passage::HEADER_STRATEGY
     )
 
+  def test_valid_jwt
+    user_id = PassageClient.auth.validate_jwt(ENV["PSG_JWT"])
+    assert_equal ENV["TEST_USER_ID"], user_id
+  end
+
   def test_valid_authenticate_token
     user_id = PassageClient.auth.authenticate_token(ENV["PSG_JWT"])
     assert_equal ENV["TEST_USER_ID"], user_id


### PR DESCRIPTION
[Jira Ticket](https://passage-identity.atlassian.net/browse/PSG-3182)

## Description
Gives a depreciation warning for the `authenticate_request` function.
Creates a `validate_jwt` function that takes the token and returns the user id. 
