### PR TITLE
Maintain use of signout function instead of revoke_user_token

### DIFF
--- a/docs/custom/AuthApi.md
+++ b/docs/custom/AuthApi.md
@@ -2,19 +2,22 @@
 
 All URIs are relative to *https://api.passage.id/v1*
 
-| Method | HTTP request | Description |
-| ------ | ------------ | ----------- |
-| [**revoke_user_refresh_tokens**](TokensApi.md#revoke_user_refresh_tokens) | **DELETE** /apps/{app_id}/users/{user_id}/tokens | **Deprecated:** Revokes refresh tokens |
-| [**validate_jwt**](TokensApi.md#validate_jwt) | n/a | Validates jwt token
+| Method | Description |
+| ------ | ----------- |
+| [**authenticate_request**](TokensApi.md#revoke_user_refresh_tokens) |  **Deprecated:** Revokes refresh tokens |
+| [**validate_jwt**](TokensApi.md#validate_jwt) |  Validates jwt token
 
 
-## revoke_user_refresh_tokens
 
-> revoke_user_refresh_tokens(user_id)
+---
 
-Revokes refresh tokens
+## authenticate_request (deprecated)
 
-Revokes all refresh tokens for a user
+> authenticate_request(request)
+
+Validates that request has the correct jwt token
+
+Validates that request has the correct jwt token
 
 ### Examples
 
@@ -24,39 +27,36 @@ require 'passageidentity'
 class ApplicationController < ActionController::Base
     PassageClient = Passage::Client.new(app_id: PASSAGE_APP_ID, api_key: PASSAGE_API_KEY)
 
-  def revoke_passage_user_tokens!
+  def authorize!
     begin
-        # tokens are revoked
-        revoke = PassageClient.auth.revoke_user_refresh_tokens(USER_ID)
+      request.to_hash()
+      @user_id = Passage.auth.authenticate_request(request)
+      session[:psg_user_id] = @user_id
     rescue Exception => e
-        # handle exception (user is not authorized)
+      # unauthorized
+      redirect_to "/unauthorized"
     end
   end
 end
 ```
 
-
 ### Parameters
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| **user_id** | **String** | User ID |  |
+| **request** | **RequestObject** | request |  |
 
 ### Return type
 
-bool
+[**UserInfo**](UserInfo.md)
 
 ### Authorization
 
 [bearerAuth](../README.md#bearerAuth)
 
-### HTTP request headers
 
-- **Content-Type**: Not defined
-- **Accept**: application/json
 
 ---
-
 
 ## validate_jwt
 

--- a/docs/custom/AuthApi.md
+++ b/docs/custom/AuthApi.md
@@ -4,9 +4,9 @@ All URIs are relative to *https://api.passage.id/v1*
 
 | Method | Description |
 | ------ | ----------- |
-| [**authenticate_request**](TokensApi.md#revoke_user_refresh_tokens) |  **Deprecated:** Revokes refresh tokens |
-| [**revoke_user_refresh_tokens**](TokensApi.md#revoke_user_refresh_tokens) | Revokes user tokens |
-| [**validate_jwt**](TokensApi.md#validate_jwt) |  Validates jwt token
+| [**authenticate_request**](AuthApi.md#authenticate_request) |  **Deprecated:** Revokes refresh tokens |
+| [**revoke_user_refresh_tokens**](AuthApi.md#revoke_user_refresh_tokens) | Revokes user tokens |
+| [**validate_jwt**](AuthApi.md#validate_jwt) |  Validates jwt token
 
 
 ---

--- a/docs/custom/AuthApi.md
+++ b/docs/custom/AuthApi.md
@@ -5,8 +5,8 @@ All URIs are relative to *https://api.passage.id/v1*
 | Method | Description |
 | ------ | ----------- |
 | [**authenticate_request**](TokensApi.md#revoke_user_refresh_tokens) |  **Deprecated:** Revokes refresh tokens |
+| [**revoke_user_refresh_tokens**](TokensApi.md#revoke_user_refresh_tokens) | Revokes user tokens |
 | [**validate_jwt**](TokensApi.md#validate_jwt) |  Validates jwt token
-
 
 
 ---
@@ -17,7 +17,6 @@ All URIs are relative to *https://api.passage.id/v1*
 
 Validates that request has the correct jwt token
 
-Validates that request has the correct jwt token
 
 ### Examples
 
@@ -55,14 +54,55 @@ end
 [bearerAuth](../README.md#bearerAuth)
 
 
+---
+
+## revoke_user_refresh_tokens()
+
+> revoke_user_refresh_tokens(user_id)
+
+Revokes user tokens
+
+### Examples
+
+```ruby
+require 'passageidentity'
+
+class ApplicationController < ActionController::Base
+    PassageClient = Passage::Client.new(app_id: PASSAGE_APP_ID, api_key: PASSAGE_API_KEY)
+
+  def authorize!
+    begin
+      revoke = PassageClient.auth.revoke_user_refresh_tokens(USER_ID)
+    rescue Exception => e
+      # handle exception (user is not authorized)
+      # unauthorized
+      redirect_to "/unauthorized"
+    end
+  end
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user_id** | **string** | user id |  |
+
+### Return type
+
+boolean
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+
 
 ---
 
 ## validate_jwt
 
 > validate_jwt(token)
-
-Validates jwt token
 
 Validates jwt token for a user
 

--- a/docs/custom/UserApi.md
+++ b/docs/custom/UserApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *https://api.passage.id/v1*
 | [**update**](UsersApi.md#update) | **PATCH** /apps/{app_id}/users/{user_id} | Update User |
 | [**delete_device**](UsersApi.md#delete_device) | **DELETE** /apps/{app_id}/users/{user_id}/devices/{device_id} | Delete a device for a user |
 | [**list_devices**](UsersApi.md#list_devices) | **GET** /apps/{app_id}/users/{user_id}/devices | List User Devices |
+| [**signout**](UsersApi.md#signout) | DELETE /apps/{app_id}/users/{user_id}/tokens | Signout of user |
 
 
 ## activate
@@ -368,3 +369,51 @@ end
 - **Content-Type**: Not defined
 - **Accept**: application/json
 
+---
+
+## signout
+
+> signout(user_id)
+
+Revokes refresh tokens
+
+Revokes all refresh tokens for a user
+
+### Examples
+
+```ruby
+require 'passageidentity'
+
+class ApplicationController < ActionController::Base
+    PassageClient = Passage::Client.new(app_id: PASSAGE_APP_ID, api_key: PASSAGE_API_KEY)
+
+  def revoke_passage_user_tokens!
+    begin
+        # tokens are revoked
+        revoke = PassageClient.auth.signout(USER_ID)
+    rescue Exception => e
+        # handle exception (user is not authorized)
+    end
+  end
+end
+```
+
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **user_id** | **String** | User ID |  |
+
+### Return type
+
+bool
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json

--- a/docs/custom/UserApi.md
+++ b/docs/custom/UserApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *https://api.passage.id/v1*
 | [**update**](UsersApi.md#update) | **PATCH** /apps/{app_id}/users/{user_id} | Update User |
 | [**delete_device**](UsersApi.md#delete_device) | **DELETE** /apps/{app_id}/users/{user_id}/devices/{device_id} | Delete a device for a user |
 | [**list_devices**](UsersApi.md#list_devices) | **GET** /apps/{app_id}/users/{user_id}/devices | List User Devices |
-| [**signout**](UsersApi.md#signout) | DELETE /apps/{app_id}/users/{user_id}/tokens | Signout of user |
+| [**signout**](UsersApi.md#signout) | DELETE /apps/{app_id}/users/{user_id}/tokens | **Deprecated:** Signout a user |
 
 
 ## activate

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -128,18 +128,4 @@ module Passage
       end
     end
   end
-
-  def revoke_user_refresh_tokens(user_id)
-    begin
-      client = OpenapiClient::TokensApi.new
-      response = client.revoke_user_refresh_tokens(@app_id, user_id)
-      return true
-    rescue Faraday::Error => e
-      raise PassageError.new(
-              message: "failed to revoke user's refresh tokens",
-              status_code: e.response[:status],
-              body: e.response[:body]
-            )
-    end
-  end
 end

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -55,7 +55,7 @@ module Passage
     end
 
     def authenticate_request(request)
-      warn "[DEPRECATION] `authenticate_request` is deprecated.  Please use `validate_jwt(token)` instead."
+      warn "[DEPRECATION] `auth.authenticate_request()` is deprecated.  Please use `auth.validate_jwt()` instead."
 
       # Get the token based on the strategy
       if @auth_strategy === Passage::COOKIE_STRATEGY

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -127,5 +127,19 @@ module Passage
         raise PassageError.new(message: e.message)
       end
     end
+
+    def revoke_user_refresh_tokens(user_id)
+      begin
+        client = OpenapiClient::TokensApi.new
+        response = client.revoke_user_refresh_tokens(@app_id, user_id)
+        return true
+      rescue Faraday::Error => e
+        raise PassageError.new(
+                message: "failed to revoke user's refresh tokens",
+                status_code: e.response[:status],
+                body: e.response[:body]
+              )
+      end
+    end
   end
 end

--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -189,6 +189,7 @@ module Passage
     end
 
     def signout(user_id:)
+      warn "[DEPRECATION] `user.signout()` is deprecated.  Please use `auth.revoke_user_refresh_tokens()` instead."
       user_exists?(user_id)
       begin
         tokens_client = OpenapiClient::TokensApi.new


### PR DESCRIPTION
The PR always had the revoke_user_token function. The function was called signout. I removed the function I previously created and clarified the docs. 