### PR TITLE
PSG-4840 openapi client import error

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -29,3 +29,5 @@ rm -rf ./lib/openapi_client.rb
 mv ./generated/lib/openapi_client.rb ./lib/openapi_client.rb
 
 rm -rf ./generated
+
+sed -i 's/require /require_relative /g' ./lib/openapi_client.rb

--- a/lib/openapi_client.rb
+++ b/lib/openapi_client.rb
@@ -11,7 +11,7 @@ OpenAPI Generator version: 7.1.0
 =end
 
 # Common files
-require_relative 'openapi_client/api_client'
+require './openapi_client/api_client'
 require_relative 'openapi_client/api_error'
 require_relative 'openapi_client/version'
 require_relative 'openapi_client/configuration'

--- a/lib/openapi_client.rb
+++ b/lib/openapi_client.rb
@@ -11,7 +11,7 @@ OpenAPI Generator version: 7.1.0
 =end
 
 # Common files
-require './openapi_client/api_client'
+require './api_client.rb'
 require_relative 'openapi_client/api_error'
 require_relative 'openapi_client/version'
 require_relative 'openapi_client/configuration'

--- a/lib/openapi_client.rb
+++ b/lib/openapi_client.rb
@@ -11,7 +11,7 @@ OpenAPI Generator version: 7.1.0
 =end
 
 # Common files
-require './api_client'
+require_relative 'openapi_client/api_client'
 require_relative 'openapi_client/api_error'
 require_relative 'openapi_client/version'
 require_relative 'openapi_client/configuration'

--- a/lib/openapi_client.rb
+++ b/lib/openapi_client.rb
@@ -11,7 +11,7 @@ OpenAPI Generator version: 7.1.0
 =end
 
 # Common files
-require './openapi_client/api_client.rb'
+require './api_client'
 require_relative 'openapi_client/api_error'
 require_relative 'openapi_client/version'
 require_relative 'openapi_client/configuration'

--- a/lib/openapi_client.rb
+++ b/lib/openapi_client.rb
@@ -11,7 +11,7 @@ OpenAPI Generator version: 7.1.0
 =end
 
 # Common files
-require './api_client.rb'
+require './openapi_client/api_client.rb'
 require_relative 'openapi_client/api_error'
 require_relative 'openapi_client/version'
 require_relative 'openapi_client/configuration'


### PR DESCRIPTION
## What's New?

Fix in `generate.sh` to have `openapi_client.rb` to replace `require` with `require_relative`. This ensures that there does not have to be dev intervention whenever a new sdk is generated.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
Generated sdk locally to test