### PR TITLE
build: docker now writes codegen files as current user instead of root

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -8,7 +8,7 @@ fi
 
 file="$1"
 
-docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:latest generate \
+docker run --rm -v "${PWD}:/local" -u $(id -u) openapitools/openapi-generator-cli:latest generate \
   -i "/local/$file" \
   -g ruby \
   -o /local/generated \


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

using the openapitools docker image to codegen wrote the generated files as root, which caused the GHA runner to fail to cp/mv them around afterwards.

setting docker to run as the current user ensures the host machine has the correct file permissions.

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
