### PR TITLE
chore: adjusts gemspec files to only include lib directory

### DIFF
--- a/passageidentity.gemspec
+++ b/passageidentity.gemspec
@@ -19,12 +19,8 @@ Gem::Specification.new do |s|
   s.metadata['source_code_uri'] = 'https://github.com/passageidentity/passage-ruby'
   s.metadata['changelog_uri'] = 'https://github.com/passageidentity/passage-ruby/CHANGELOG.md'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  s.files = ['lib/passageidentity.rb']
+  s.files = Dir['lib/**/*.rb']
   s.require_paths = ['lib']
-  s.bindir = 'exe'
-  s.executables = s.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
 
   s.add_dependency 'faraday', '>= 0.17.0', '< 2.0'
   s.add_dependency 'jwt', '~> 2.3', '>= 2.3.0'


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Adds back in source files for package artifact

References
- [RubyGems](https://guides.rubygems.org/make-your-own-gem/#:~:text=If%20you%E2%80%99ve%20added%20more%20files%20to%20your%20gem%2C%20make%20sure%20to%20remember%20to%20add%20them%20to%20your%20gemspec%E2%80%99s%20files%20array%20before%20publishing%20a%20new%20gem!%20For%20this%20reason%20(among%20others)%2C%20many%20developers%20automate%20this%20with%20Hoe%2C%20Jeweler%2C%20Rake%2C%20lorem%2C%20or%20just%20a%20dynamic%20gemspec%20.) (specifically [this example](https://github.com/wycats/newgem-template/blob/master/newgem.gemspec) from it)

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
