### PR TITLE
fix: use keywords for revoke_device

### DIFF
--- a/lib/passageidentity/user_api.rb
+++ b/lib/passageidentity/user_api.rb
@@ -147,7 +147,7 @@ module Passage
     end
 
     def delete_device(user_id:, device_id:)
-      revoke_device(user_id, device_id)
+      revoke_device(user_id: user_id, device_id: device_id)
       true
     end
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This addresses the following error:
```
wrong number of arguments (given 2, expected 0; required keywords: user_id, device_id)
/lib/passageidentity/user_api.rb:135:in `revoke_device'
/lib/passageidentity/user_api.rb:150:in `delete_device'
```
## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
