### PR TITLE
fix: validate_jwt now refreshes cache if it is expired after client initialization

### DIFF
--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -64,7 +64,9 @@ module Passage
     def validate_jwt(token)
       raise ArgumentError, 'jwt is required.' unless token && !token.empty?
 
-      unless get_cache(@app_id)
+      begin
+        fetch_jwks
+      rescue Faraday::Error
         raise PassageError.new(
           status_code: 401,
           body: {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- fixes an issue where `validate_jwt` would only try to fetch the jwks from cache, so if the cache was expired it would not re-fetch

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
