### PR TITLE
fix: jwt validation correctly compares the aud with both app id and auth origin

### DIFF
--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -162,7 +162,7 @@ module Passage
       app_cache = get_cache(@app_id)
 
       if app_cache
-        @jwks, @auth_origin = app_cache
+        @jwks = app_cache
       else
         auth_gw_connection =
           Faraday.new(url: 'https://auth.passage.id') do |f|

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -82,7 +82,7 @@ module Passage
           nil,
           true,
           {
-            aud: [@app_id],
+            aud: @app_id,
             verify_aud: true,
             algorithms: ['RS256'],
             jwks: @jwks

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -76,15 +76,13 @@ module Passage
         )
       end
 
-      audiences = [@auth_origin, @app_id]
-
       claims =
         JWT.decode(
           token,
           nil,
           true,
           {
-            aud: audiences,
+            aud: [@app_id],
             verify_aud: true,
             algorithms: ['RS256'],
             jwks: @jwks
@@ -172,10 +170,6 @@ module Passage
             f.adapter :net_http
           end
 
-        # fetch the public key if not in cache
-        app = fetch_app
-
-        @auth_origin = app.auth_origin
         response =
           auth_gw_connection.get("/v1/apps/#{@app_id}/.well-known/jwks.json")
 


### PR DESCRIPTION
## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There was a bug where the `validate_jwt` method was not using the correct auth origin value when verifying the jwt audience.

The jwt would still pass verification if it was the new structure, since it also includes the app id in the audience array. But it would compare a `nil` auth origin to the jwt's real auth origin.

- c86e409408ee9ddd249f3dc65658bad0f1d29232 is what minimally fixes the issue
- d88248c9ed7a5b6d29f3683fd7049db996081a54 removes the auth origin comparison all together so the audience is only checked against app id (compatible with new jwt structure)

To repro:
Change the expected audience to only check for `@auth_origin` and run the auth tests. they should error, stating
```
Passage::PassageError: Invalid audience. Expected [nil], received ["http://localhost:4173", "<app id>"]
```
where `nil` is supposed to be the value of `@auth_origin`

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
