### PR TITLE
ci: pin rubygems to 3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: '3.1'
-          rubygems: 'latest'
+          rubygems: '3.5'
         if: ${{ steps.release.outputs.release_created }}
       - uses: rubygems/release-gem@v1
         id: publish


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

bundler seems to have [broken](https://github.com/passageidentity/passage-ruby/actions/runs/12438693805/job/34731077667) in ruby gems 3.6/bundler 3.6, so pinning to 3.5 for now

[last successful run](https://github.com/passageidentity/passage-ruby/actions/runs/12306233604/job/34347533159) for reference (note the version difference with rubygems and bundler

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
