### PR TITLE
fix: adds error handling for OpenApi errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,5 @@ Layout/LineLength:
 Metrics/MethodLength:
   Max: 50
     
+Metrics/AbcSize:
+  Max: 20

--- a/lib/passageidentity/auth.rb
+++ b/lib/passageidentity/auth.rb
@@ -108,15 +108,15 @@ module Passage
 
     def handle_magic_link_creation(args)
       @magic_links_client.create_magic_link(@app_id, args, @req_opts).magic_link
-    rescue Faraday::Error => e
-      raise PassageError.new(
-        status_code: e.response[:status],
-        body: e.response[:body]
-      )
     rescue OpenapiClient::ApiError => e
       raise PassageError.new(
         status_code: e.code,
         body: try_parse_json_string(e.response_body)
+      )
+    rescue Faraday::Error => e
+      raise PassageError.new(
+        status_code: e.response[:status],
+        body: e.response[:body]
       )
     end
 

--- a/lib/passageidentity/user.rb
+++ b/lib/passageidentity/user.rb
@@ -15,7 +15,7 @@ module Passage
     end
 
     def get(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         response = @user_client.get_user(@app_id, user_id, @req_opts)
@@ -34,7 +34,7 @@ module Passage
     end
 
     def get_by_identifier(identifier:)
-      raise ArgumentError, 'identifier is required.' unless identifier && !identifier.empty?
+      raise ArgumentError, 'identifier is required.' if blank_str(identifier)
 
       begin
         req_opts = set_get_by_identifier_query_params(identifier: identifier)
@@ -55,7 +55,7 @@ module Passage
     end
 
     def activate(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         response = @user_client.activate_user(@app_id, user_id, @req_opts)
@@ -74,7 +74,7 @@ module Passage
     end
 
     def deactivate(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         response = @user_client.deactivate_user(@app_id, user_id, @req_opts)
@@ -93,8 +93,8 @@ module Passage
     end
 
     def update(user_id:, options:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
-      raise ArgumentError, 'options are required.' unless options && !options.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'options are required.' if options.empty?
 
       begin
         response = @user_client.update_user(@app_id, user_id, options, @req_opts)
@@ -113,7 +113,10 @@ module Passage
     end
 
     def create(args:)
-      raise ArgumentError, 'At least one of args.email or args.phone is required.' unless args['phone'] || args['email']
+      if blank_str(args['email']) && blank_str(args['phone'])
+        raise ArgumentError,
+              'At least one of args.email or args.phone is required.'
+      end
 
       begin
         response = @user_client.create_user(@app_id, args, @req_opts)
@@ -132,7 +135,7 @@ module Passage
     end
 
     def delete(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         @user_client.delete_user(@app_id, user_id, @req_opts)
@@ -151,8 +154,8 @@ module Passage
     end
 
     def revoke_device(user_id:, device_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
-      raise ArgumentError, 'device_id is required.' unless device_id && !device_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'device_id is required.' if blank_str(device_id)
 
       begin
         @user_device_client.delete_user_devices(@app_id, user_id, device_id, @req_opts)
@@ -170,7 +173,7 @@ module Passage
     end
 
     def list_devices(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         response = @user_device_client.list_user_devices(@app_id, user_id, @req_opts)
@@ -189,7 +192,7 @@ module Passage
     end
 
     def revoke_refresh_tokens(user_id:)
-      raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
+      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
 
       begin
         @tokens_client.revoke_user_refresh_tokens(@app_id, user_id, @req_opts)
@@ -207,6 +210,11 @@ module Passage
     end
 
     private
+
+    def blank_str(str)
+      blank_pattern = /\A[[:space:]]*\z/
+      str.empty? || blank_pattern.match?(str)
+    end
 
     def set_get_by_identifier_query_params(identifier:)
       req_opts = @req_opts.dup

--- a/lib/passageidentity/user.rb
+++ b/lib/passageidentity/user.rb
@@ -15,7 +15,7 @@ module Passage
     end
 
     def get(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         response = @user_client.get_user(@app_id, user_id, @req_opts)
@@ -34,7 +34,7 @@ module Passage
     end
 
     def get_by_identifier(identifier:)
-      raise ArgumentError, 'identifier is required.' if blank_str(identifier)
+      raise ArgumentError, 'identifier is required.' if blank_str?(identifier)
 
       begin
         req_opts = set_get_by_identifier_query_params(identifier: identifier)
@@ -55,7 +55,7 @@ module Passage
     end
 
     def activate(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         response = @user_client.activate_user(@app_id, user_id, @req_opts)
@@ -74,7 +74,7 @@ module Passage
     end
 
     def deactivate(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         response = @user_client.deactivate_user(@app_id, user_id, @req_opts)
@@ -93,7 +93,7 @@ module Passage
     end
 
     def update(user_id:, options:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
       raise ArgumentError, 'options are required.' if options.empty?
 
       begin
@@ -113,7 +113,7 @@ module Passage
     end
 
     def create(args:)
-      if blank_str(args['email']) && blank_str(args['phone'])
+      if blank_str?(args['email']) && blank_str?(args['phone'])
         raise ArgumentError,
               'At least one of args.email or args.phone is required.'
       end
@@ -135,7 +135,7 @@ module Passage
     end
 
     def delete(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         @user_client.delete_user(@app_id, user_id, @req_opts)
@@ -154,8 +154,8 @@ module Passage
     end
 
     def revoke_device(user_id:, device_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
-      raise ArgumentError, 'device_id is required.' if blank_str(device_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
+      raise ArgumentError, 'device_id is required.' if blank_str?(device_id)
 
       begin
         @user_device_client.delete_user_devices(@app_id, user_id, device_id, @req_opts)
@@ -173,7 +173,7 @@ module Passage
     end
 
     def list_devices(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         response = @user_device_client.list_user_devices(@app_id, user_id, @req_opts)
@@ -192,7 +192,7 @@ module Passage
     end
 
     def revoke_refresh_tokens(user_id:)
-      raise ArgumentError, 'user_id is required.' if blank_str(user_id)
+      raise ArgumentError, 'user_id is required.' if blank_str?(user_id)
 
       begin
         @tokens_client.revoke_user_refresh_tokens(@app_id, user_id, @req_opts)
@@ -211,7 +211,7 @@ module Passage
 
     private
 
-    def blank_str(str)
+    def blank_str?(str)
       blank_pattern = /\A[[:space:]]*\z/
       str.empty? || blank_pattern.match?(str)
     end

--- a/lib/passageidentity/user.rb
+++ b/lib/passageidentity/user.rb
@@ -20,6 +20,11 @@ module Passage
       begin
         response = @user_client.get_user(@app_id, user_id, @req_opts)
         response.user
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -34,6 +39,11 @@ module Passage
       begin
         req_opts = set_get_by_identifier_query_params(identifier: identifier)
         response = @user_client.list_paginated_users(@app_id, req_opts)
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -50,6 +60,11 @@ module Passage
       begin
         response = @user_client.activate_user(@app_id, user_id, @req_opts)
         response.user
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -64,6 +79,11 @@ module Passage
       begin
         response = @user_client.deactivate_user(@app_id, user_id, @req_opts)
         response.user
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -76,25 +96,39 @@ module Passage
       raise ArgumentError, 'user_id is required.' unless user_id && !user_id.empty?
       raise ArgumentError, 'options are required.' unless options && !options.empty?
 
-      response = @user_client.update_user(@app_id, user_id, options, @req_opts)
-      response.user
-    rescue Faraday::Error => e
-      raise PassageError.new(
-        status_code: e.response[:status],
-        body: e.response[:body]
-      )
+      begin
+        response = @user_client.update_user(@app_id, user_id, options, @req_opts)
+        response.user
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
+      rescue Faraday::Error => e
+        raise PassageError.new(
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
+      end
     end
 
     def create(args:)
       raise ArgumentError, 'At least one of args.email or args.phone is required.' unless args['phone'] || args['email']
 
-      response = @user_client.create_user(@app_id, args, @req_opts)
-      response.user
-    rescue Faraday::Error => e
-      raise PassageError.new(
-        status_code: e.response[:status],
-        body: e.response[:body]
-      )
+      begin
+        response = @user_client.create_user(@app_id, args, @req_opts)
+        response.user
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
+      rescue Faraday::Error => e
+        raise PassageError.new(
+          status_code: e.response[:status],
+          body: e.response[:body]
+        )
+      end
     end
 
     def delete(user_id:)
@@ -102,6 +136,11 @@ module Passage
 
       begin
         @user_client.delete_user(@app_id, user_id, @req_opts)
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           'failed to delete Passage User',
@@ -117,6 +156,11 @@ module Passage
 
       begin
         @user_device_client.delete_user_devices(@app_id, user_id, device_id, @req_opts)
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -131,6 +175,11 @@ module Passage
       begin
         response = @user_device_client.list_user_devices(@app_id, user_id, @req_opts)
         response.devices
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -144,6 +193,11 @@ module Passage
 
       begin
         @tokens_client.revoke_user_refresh_tokens(@app_id, user_id, @req_opts)
+      rescue OpenapiClient::ApiError => e
+        raise PassageError.new(
+          status_code: e.code,
+          body: try_parse_json_string(e.response_body)
+        )
       rescue Faraday::Error => e
         raise PassageError.new(
           status_code: e.response[:status],
@@ -173,6 +227,12 @@ module Passage
       end
 
       get(user_id: users.first.id)
+    end
+
+    def try_parse_json_string(string)
+      JSON.parse(string)
+    rescue JSON::ParserError
+      string
     end
   end
 end


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- the errors that come back from our API servers are not `Faraday` errors, but `OpenapiClient` instead
- also fixes another error where the param guard wasn't correctly checking an empty `''` string
	- this fix will be added as a separate line item in the squash commit message

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
